### PR TITLE
Bugfix: Incorrect Graphviz Graph for Nodes with colon in Name

### DIFF
--- a/controllers/AlgorithmControllers.py
+++ b/controllers/AlgorithmControllers.py
@@ -41,4 +41,3 @@ class AlgorithmController(ABC):
             df, timestamp_col, activity_col, cases_col, **additional_cols
         )
         self.model = self.create_empty_model(cases)
-        return self.perform_mining()

--- a/exceptions/graph_exceptions.py
+++ b/exceptions/graph_exceptions.py
@@ -24,3 +24,10 @@ class EdgeDoesNotExistException(Exception):
     def __init__(self, source, target):
         self.message = f"Edge from {source} to {target} does not exist."
         super().__init__(self.message)
+
+
+class InvalidNodeNameException(Exception):
+
+    def __init__(self, node):
+        self.message = f"Node '{node}' is not a valid node name."
+        super().__init__(self.message)

--- a/graphs/visualization/base_graph.py
+++ b/graphs/visualization/base_graph.py
@@ -4,11 +4,10 @@ from exceptions.graph_exceptions import (
     DuplicateEdgeException,
     NodeDoesNotExistException,
     EdgeDoesNotExistException,
+    InvalidNodeNameException,
 )
 
 
-# TODO: substitute : for ___ in node ids and edges, but not in labels
-# but also substitute ___ for : when getting the node or edge in this application
 class Node:
 
     def __init__(
@@ -78,6 +77,9 @@ class BaseGraph:
         data: dict[str, str | int | float] = None,
         **node_attributes,
     ) -> None:
+
+        if self.colon_substitute in str(id):
+            raise InvalidNodeNameException(id)
 
         if self.contains_node(id):
             raise DuplicateNodeException(id)

--- a/graphs/visualization/base_graph.py
+++ b/graphs/visualization/base_graph.py
@@ -78,15 +78,19 @@ class BaseGraph:
         data: dict[str, str | int | float] = None,
         **node_attributes,
     ) -> None:
+
         if self.contains_node(id):
             raise DuplicateNodeException(id)
+
         node = Node(id, label, data)
         self.nodes[node.get_id()] = node
+
         if "filled" not in node_attributes.get("style", ""):
             if "style" in node_attributes:
                 node_attributes["style"] += ", filled"
             else:
                 node_attributes["style"] = "filled"
+
         graphviz_id = self.substitiute_colons(node.get_id())
         self.graph.node(graphviz_id, node.get_label(), **node_attributes)
 
@@ -148,10 +152,10 @@ class BaseGraph:
         weight: int = 1,
         **edge_attributes,
     ) -> None:
-        if str(source_id) not in self.nodes:
+        if not self.contains_node(source_id):
             raise NodeDoesNotExistException(source_id)
 
-        if str(target_id) not in self.nodes:
+        if not self.contains_node(target_id):
             raise NodeDoesNotExistException(target_id)
 
         if self.contains_edge(source_id, target_id):
@@ -159,6 +163,7 @@ class BaseGraph:
 
         edge = Edge(source_id, target_id, weight)
         self.edges[(edge.source, edge.destination)] = edge
+
         if weight == None:
             label = ""
         else:
@@ -181,9 +186,11 @@ class BaseGraph:
         return self.nodes[str(node_id)]
 
     def get_edge(self, source: str | int, destination: str | int) -> Edge:
-        if not self.contains_edge(source, destination):
-            raise EdgeDoesNotExistException(source, destination)
-        return self.edges[(str(source), str(destination))]
+        source_id = str(source).replace(self.colon_substitute, ":")
+        destination_id = str(destination).replace(self.colon_substitute, ":")
+        if not self.contains_edge(source_id, destination_id):
+            raise EdgeDoesNotExistException(source_id, destination_id)
+        return self.edges[(source_id, destination_id)]
 
     def contains_node(self, id: str | int) -> bool:
         return str(id) in self.nodes

--- a/graphs/visualization/base_graph.py
+++ b/graphs/visualization/base_graph.py
@@ -87,7 +87,7 @@ class BaseGraph:
                 node_attributes["style"] += ", filled"
             else:
                 node_attributes["style"] = "filled"
-        graphviz_id = node.get_id().replace(":", self.colon_substitute)
+        graphviz_id = self.substitiute_colons(node.get_id())
         self.graph.node(graphviz_id, node.get_label(), **node_attributes)
 
     def add_start_node(self, id: str = "Start") -> None:
@@ -141,7 +141,6 @@ class BaseGraph:
             else:
                 self.add_edge(node, ending_node, weight=None, **edge_attributes)
 
-    # Need better naming to not collide with the add_edge method from inheritance
     def add_edge(
         self,
         source_id: str | int,
@@ -164,8 +163,10 @@ class BaseGraph:
             label = ""
         else:
             label = str(weight)
-        graphviz_source_id = edge.source.replace(":", self.colon_substitute)
-        graphviz_target_id = edge.destination.replace(":", self.colon_substitute)
+
+        graphviz_source_id = self.substitiute_colons(edge.source)
+        graphviz_target_id = self.substitiute_colons(edge.destination)
+
         self.graph.edge(
             graphviz_source_id,
             graphviz_target_id,
@@ -174,9 +175,10 @@ class BaseGraph:
         )
 
     def get_node(self, id: str | int) -> Node:
-        if not self.contains_node(id):
-            raise NodeDoesNotExistException(id)
-        return self.nodes[str(id)]
+        node_id = str(id).replace(self.colon_substitute, ":")
+        if not self.contains_node(node_id):
+            raise NodeDoesNotExistException(node_id)
+        return self.nodes[str(node_id)]
 
     def get_edge(self, source: str | int, destination: str | int) -> Edge:
         if not self.contains_edge(source, destination):
@@ -216,3 +218,9 @@ class BaseGraph:
             for key, value in node.get_data().items():
                 description += f"\n**{key}:** {value}"
         return node.get_id(), description
+
+    def substitiute_colons(self, string: str) -> str:
+        return string.replace(":", self.colon_substitute)
+
+    def substitute_colons_back(self, string: str) -> str:
+        return string.replace(self.colon_substitute, ":")

--- a/graphs/visualization/base_graph.py
+++ b/graphs/visualization/base_graph.py
@@ -57,6 +57,9 @@ class Edge:
 
 
 class BaseGraph:
+
+    colon_substitute: str = "___"
+
     def __init__(
         self,
         **graph_attributes,
@@ -84,7 +87,8 @@ class BaseGraph:
                 node_attributes["style"] += ", filled"
             else:
                 node_attributes["style"] = "filled"
-        self.graph.node(node.get_id(), node.get_label(), **node_attributes)
+        graphviz_id = node.get_id().replace(":", self.colon_substitute)
+        self.graph.node(graphviz_id, node.get_label(), **node_attributes)
 
     def add_start_node(self, id: str = "Start") -> None:
         self.add_node(id, shape="circle", style="filled, bold", fillcolor="green")
@@ -160,9 +164,11 @@ class BaseGraph:
             label = ""
         else:
             label = str(weight)
+        graphviz_source_id = edge.source.replace(":", self.colon_substitute)
+        graphviz_target_id = edge.destination.replace(":", self.colon_substitute)
         self.graph.edge(
-            edge.source,
-            edge.destination,
+            graphviz_source_id,
+            graphviz_target_id,
             label=label,
             **edge_attributes,
         )

--- a/tests/graphs/visualization/base_graph_test.py
+++ b/tests/graphs/visualization/base_graph_test.py
@@ -5,6 +5,7 @@ from exceptions.graph_exceptions import (
     DuplicateEdgeException,
     NodeDoesNotExistException,
     EdgeDoesNotExistException,
+    InvalidNodeNameException,
 )
 
 
@@ -207,6 +208,44 @@ class TestBaseGraph(unittest.TestCase):
         self.assertEqual(len(edges), 2)
         self.assertEqual(edges[0].get_edge(), ("1", "2", 1))
         self.assertEqual(edges[1].get_edge(), ("2", "3", 1))
+
+    def test_node_id_with_triple_underscore_throws_exception(self):
+        graph = BaseGraph()
+        with self.assertRaises(InvalidNodeNameException):
+            graph.add_node(id="node1___", label="node1___")
+
+    def test_node_id_colon_substituted_with_trible_underscore_graphviz(self):
+        graph = BaseGraph()
+        graph.add_node(id="node1:1")
+        graphviz_string = graph.get_graphviz_string()
+
+        self.assertTrue(graph.contains_node("node1:1"))
+        self.assertTrue("node1___1" in graphviz_string)
+
+    def test_edge_source_colon_substituted_with_trible_underscore_graphviz(self):
+        graph = BaseGraph()
+        graph.add_node(id="node:1")
+        graph.add_node(id="node2")
+        graph.add_edge("node:1", "node2")
+        graphviz_string = graph.get_graphviz_string()
+
+        self.assertTrue(graph.contains_edge("node:1", "node2"))
+        self.assertTrue("node___1 -> node2" in graphviz_string)
+
+    def test_get_node_substitutes_colon_back(self):
+        graph = BaseGraph()
+        graph.add_node(id="node:1")
+        node = graph.get_node("node___1")
+        self.assertEqual(node.id, "node:1")
+
+    def test_get_edge_substitutes_colon_back(self):
+        graph = BaseGraph()
+        graph.add_node(id="node:1")
+        graph.add_node(id="node2")
+        graph.add_edge("node:1", "node2")
+        edge = graph.get_edge("node___1", "node2")
+        self.assertEqual(edge.source, "node:1")
+        self.assertEqual(edge.destination, "node2")
 
 
 if __name__ == "__main__":

--- a/views/AlgorithmViewInterface.py
+++ b/views/AlgorithmViewInterface.py
@@ -85,7 +85,7 @@ class AlgorithmViewInterface(ViewInterface, ABC):
             print(ex)
             st.session_state.error = (
                 ex.message
-                + "\n Please check the input data. The string'___' is not allowed in node names."
+                + "\n Please check the input data. The string '___' is not allowed in node names."
             )
             to_home()
 

--- a/views/AlgorithmViewInterface.py
+++ b/views/AlgorithmViewInterface.py
@@ -5,6 +5,7 @@ from graphs.visualization.base_graph import BaseGraph
 from components.interactiveGraph import interactiveGraph
 from components.buttons import home_button, to_home, navigation_button
 from time import time
+from exceptions.graph_exceptions import InvalidNodeNameException
 
 
 class AlgorithmViewInterface(ViewInterface, ABC):
@@ -77,7 +78,17 @@ class AlgorithmViewInterface(ViewInterface, ABC):
         with st.sidebar:
             self.render_sidebar()
         start = time()
-        self.controller.perform_mining()
+        try:
+            self.controller.perform_mining()
+        except InvalidNodeNameException as ex:
+            # TODO: add logging
+            print(ex)
+            st.session_state.error = (
+                ex.message
+                + "\n Please check the input data. The string'___' is not allowed in node names."
+            )
+            to_home()
+
         end = time()
         print("Time to perform mining:", end - start)
 


### PR DESCRIPTION
**Summary:**
This PR fixes the Bug described in issue #25. Graphviz builds the graphs incorrectly if the node name (id) contains colons. The Nodes are correctly added, but the colon has a special functionality, when displaying edges. As colons could appear frequently in event names, the colons are substituted by "\_\_\_" (three underscores) in the graphviz graph. The edges stored in the application (in the base graph) still contain the colon in the id.

Additionally, back substitution has been added, when trying to get a node or edge from the BaseGraph. This is necessary to be able to get Node data after a node in the graphviz graph has been clicked, as the click event send the graphviz id.

As a consequence, nodes/event names that contain "\_\_\_" (three underscores) are not supported. As these should be seen rather rarely, this limitation should not be a problem.

**Changes Made:**
Most of the changes were made in the BaseGraph.py file. First, a class variable has been added. This variable defines the substitution string for colons. 

Afterward, the add_node method has been changed. After the node has been added to the nodes dictionary, the id is checked for colons and if a colon is present, the colon is substituted by the substitution string ("\_\_\_").  This possibly transformed id is then used in the graphviz graph. The add_edge method has been changes similarly. The edge is created in the BaseGraph and added to the edges dictionary. Afterward the source_id and target_id is checked for colons and if these are present they are replaced by "\_\_\_" and the edge is added to the graphviz graph.

The get_node method and the get_edge method have been changed to reverse this transformation. If a node, source or target (last for edges) contains the substitution string ("\_\_\_"), the string is replaced by a colon. 

Because of the back substitution of the "\_\_\_" to a colon, node names with three underscores can no longer be allowed in the application, as these would be treated the same as the same node with a colon in the position. A new Graph exception (InvalidNodeNameException)was added. If a node with "\_\_\_" in its node should be added to the graph, this exception is thrown.

As a last change, the previously mentioned exception is caught in the algorithm controller. If this exception is caught, the page is changed to the home paged, with an error message, that say that names with "\_\_\_" are not allowed.

**Testing:**
This new functionality has been tested, mostly by unit tests. The following test cases have been added:
- adding a node with colons in the name
- adding an edge, where one node name contains a colon
- get_node replaces the three underscores with a colon
- get_edge replaces the three underscores with a colon
- adding a node with three underscores in its name throws the exception

Additionally, the application has been manually tested. A dataset has been used, that had an event name with three underscores. The exception has been thrown and caught. The Page switched to the Home Page and the error message was displayed

**Issues Resolved:**
- #25 