### PR TITLE
Enhancement/increase performance of inductive mining #28

### DIFF
--- a/graphs/cuts.py
+++ b/graphs/cuts.py
@@ -70,7 +70,7 @@ def parallel_cut(graph: DFG) -> list[set[str | int]]:
     if len(graph.get_start_nodes()) == 1 or len(graph.get_end_nodes()) == 1:
         return None
 
-    inverted_dfg = create_inverted_dfg(graph)
+    inverted_dfg = graph.invert()
     partitions = inverted_dfg.get_connected_components()
 
     if len(partitions) == 1:
@@ -140,8 +140,8 @@ def loop_cut(graph: DFG) -> list[set[str | int]]:
     starting_nodes = graph.get_start_nodes()
     ending_nodes = graph.get_end_nodes()
 
-    dfg_without_end_start_nodes = create_dfg_without_nodes(
-        graph, starting_nodes.union(ending_nodes)
+    dfg_without_end_start_nodes = graph.create_dfg_without_nodes(
+        starting_nodes.union(ending_nodes)
     )
 
     # create partitions thath are not connected to each other
@@ -227,41 +227,3 @@ def loop_cut(graph: DFG) -> list[set[str | int]]:
 
     partitions = [partition_1, *filtered_partitions]
     return partitions if len(partitions) > 1 else None
-
-
-def create_dfg_without_nodes(graph: DFG, nodes: set[str | int]) -> DFG:
-    dfg_without_nodes = DFG()
-
-    for node in graph.get_nodes():
-        if node not in nodes:
-            dfg_without_nodes.add_node(node)
-
-    for edge in graph.get_edges():
-        source, destination = edge
-        if source not in nodes and destination not in nodes:
-            dfg_without_nodes.add_edge(source, destination)
-
-    return dfg_without_nodes
-
-
-def create_inverted_dfg(graph: DFG) -> DFG:
-    inverted_dfg = DFG()
-
-    edges = graph.get_edges()
-    nodes = list(graph.get_nodes())
-
-    for node in nodes:
-        inverted_dfg.add_node(node)
-
-    for i in range(len(nodes)):
-        for j in range(i + 1, len(nodes)):
-            node_1 = nodes[i]
-            node_2 = nodes[j]
-
-            if not graph.contains_edge(node_1, node_2) or not graph.contains_edge(
-                node_2, node_1
-            ):
-                inverted_dfg.add_edge(node_1, node_2)
-                inverted_dfg.add_edge(node_2, node_1)
-
-    return inverted_dfg

--- a/graphs/cuts.py
+++ b/graphs/cuts.py
@@ -16,12 +16,14 @@ def sequence_cut(graph: DFG) -> list[set[str | int]]:
     partitions = [{node} for node in graph.get_nodes()]
     nodes = list(graph.get_nodes())
 
+    reachable_nodes = {node: graph.get_reachable_nodes(node) for node in nodes}
+
     for i in range(len(nodes)):
         for j in range(i + 1, len(nodes)):
             node_1 = nodes[i]
             node_2 = nodes[j]
-            is_j_reachable_from_i = graph.is_reachable(node_1, node_2)
-            is_i_reachable_from_j = graph.is_reachable(node_2, node_1)
+            is_j_reachable_from_i = node_2 in reachable_nodes[node_1]
+            is_i_reachable_from_j = node_1 in reachable_nodes[node_2]
 
             # merge partitions if the nodes are reachable from each other or not reachable from each other
             if (is_j_reachable_from_i and is_i_reachable_from_j) or (
@@ -48,8 +50,9 @@ def sequence_cut(graph: DFG) -> list[set[str | int]]:
     for i in range(len(partitions)):
         min_partition_index = i
         for j in range(i + 1, len(partitions)):
-            if graph.is_reachable(
-                next(iter(partitions[j])), next(iter(partitions[min_partition_index]))
+            if (
+                next(iter(partitions[min_partition_index]))
+                in reachable_nodes[next(iter(partitions[j]))]
             ):
                 min_partition_index = j
 

--- a/graphs/cuts.py
+++ b/graphs/cuts.py
@@ -3,6 +3,11 @@ from collections import deque
 
 
 def exclusive_cut(graph: DFG) -> list[set[str | int]]:
+    # check if the graph has only one start node or one end node
+    # if this is the case return None, as no exclusive cut is possible
+    if len(graph.get_start_nodes()) == 1 or len(graph.get_end_nodes()) == 1:
+        return None
+
     connected_components = graph.get_connected_components()
     return connected_components if len(connected_components) > 1 else None
 
@@ -57,6 +62,11 @@ def sequence_cut(graph: DFG) -> list[set[str | int]]:
 
 
 def parallel_cut(graph: DFG) -> list[set[str | int]]:
+    # check if the graph has only one start node or one end node
+    # if this is the case return None, as no exclusive cut is possible
+    if len(graph.get_start_nodes()) == 1 or len(graph.get_end_nodes()) == 1:
+        return None
+
     inverted_dfg = create_inverted_dfg(graph)
     partitions = inverted_dfg.get_connected_components()
 

--- a/graphs/dfg.py
+++ b/graphs/dfg.py
@@ -76,7 +76,6 @@ class DFG:
 
         return connected_components
 
-    # TODO: update to new internal dfg structure
     def __bfs(self, starting_node: str | int, directed=True) -> set[str | int]:
         queue = deque([starting_node])
         visited = set([starting_node])

--- a/graphs/dfg.py
+++ b/graphs/dfg.py
@@ -64,35 +64,35 @@ class DFG:
         if node not in self.predecessor_list:
             self.predecessor_list[node] = set()
 
-    # TODO: update to new internal dfg structure
     def get_connected_components(self) -> list[set[str | int]]:
         connected_components = []
         visited = set()
 
-        for node in self.nodes:
+        for node in self.get_nodes():
             if node not in visited:
-                component = self.__bfs(node)
+                component = self.__bfs(node, directed=False)
                 connected_components.append(component)
                 visited.update(component)
 
         return connected_components
 
     # TODO: update to new internal dfg structure
-    def __bfs(self, starting_node: str | int) -> set[str | int]:
-        """Breadth-first search to find all reachable nodes from a starting node, without considering the direction of the edges."""
+    def __bfs(self, starting_node: str | int, directed=True) -> set[str | int]:
         queue = deque([starting_node])
         visited = set([starting_node])
 
         while queue:
             current_node = queue.popleft()
 
-            for node in self.nodes:
-                if node not in visited and (
-                    (current_node, node) in self.edges
-                    or (node, current_node) in self.edges
-                ):
-                    queue.append(node)
-                    visited.add(node)
+            neighbors = self.get_successors(current_node)
+
+            if not directed:
+                neighbors.update(self.get_predecessors(current_node))
+
+            for neighbor in neighbors:
+                if neighbor not in visited:
+                    queue.append(neighbor)
+                    visited.add(neighbor)
 
         return visited
 
@@ -131,15 +131,6 @@ class DFG:
         return destination in self.successor_list.get(source, set())
 
     def get_reachable_nodes(self, node: str | int) -> set[str | int]:
-        queue = deque([node])
-        visited = set([node])
-
-        while queue:
-            current_node = queue.popleft()
-
-            for node in self.nodes:
-                if node not in visited and (current_node, node) in self.edges:
-                    queue.append(node)
-                    visited.add(node)
+        visited = self.__bfs(node)
 
         return visited

--- a/graphs/dfg.py
+++ b/graphs/dfg.py
@@ -33,14 +33,9 @@ class DFG:
             self.add_node(trace[-1])
 
             for i in range(len(trace) - 1):
-                self.add_edge(trace[i], trace[i + 1], frequency)
+                self.add_edge(trace[i], trace[i + 1])
 
-    def add_edge(
-        self, source: str | int, destination: str | int, weight: int = 1
-    ) -> None:
-
-        if weight <= 0:
-            raise ValueError("Weight must be a positive integer.")
+    def add_edge(self, source: str | int, destination: str | int) -> None:
 
         if not self.contains_node(source):
             self.add_node(source)

--- a/graphs/dfg.py
+++ b/graphs/dfg.py
@@ -77,7 +77,6 @@ class DFG:
 
         while queue:
             current_node = queue.popleft()
-
             neighbors = self.get_successors(current_node)
 
             if not directed:

--- a/graphs/dfg.py
+++ b/graphs/dfg.py
@@ -127,3 +127,37 @@ class DFG:
         visited = self.__bfs(node)
 
         return visited
+
+    def invert(self) -> "DFG":
+        inverted_dfg = DFG()
+        nodes = list(self.get_nodes())
+
+        for node in nodes:
+            inverted_dfg.add_node(node)
+
+        for i in range(len(nodes)):
+            for j in range(i + 1, len(nodes)):
+                node_1 = nodes[i]
+                node_2 = nodes[j]
+
+                if not self.contains_edge(node_1, node_2) or not self.contains_edge(
+                    node_2, node_1
+                ):
+                    inverted_dfg.add_edge(node_1, node_2)
+                    inverted_dfg.add_edge(node_2, node_1)
+
+        return inverted_dfg
+
+    def create_dfg_without_nodes(self, nodes: set[str | int]) -> "DFG":
+        dfg_without_nodes = DFG()
+
+        for node in self.get_nodes():
+            if node not in nodes:
+                dfg_without_nodes.add_node(node)
+
+        for edge in self.get_edges():
+            source, destination = edge
+            if source not in nodes and destination not in nodes:
+                dfg_without_nodes.add_edge(source, destination)
+
+        return dfg_without_nodes

--- a/graphs/dfg.py
+++ b/graphs/dfg.py
@@ -97,7 +97,7 @@ class DFG:
         return self.predecessor_list.get(node, set())
 
     def get_nodes(self) -> set[str | int]:
-        return self.successor_list.keys()
+        return set(self.successor_list.keys())
 
     def get_edges(self) -> dict[tuple[str | int, str | int], int]:
         edges = set()

--- a/graphs/dfg.py
+++ b/graphs/dfg.py
@@ -142,3 +142,17 @@ class DFG:
                     visited.add(node)
 
         return False
+
+    def get_reachable_nodes(self, node: str | int) -> set[str | int]:
+        queue = deque([node])
+        visited = set([node])
+
+        while queue:
+            current_node = queue.popleft()
+
+            for node in self.nodes:
+                if node not in visited and (current_node, node) in self.edges:
+                    queue.append(node)
+                    visited.add(node)
+
+        return visited

--- a/graphs/dfg.py
+++ b/graphs/dfg.py
@@ -80,7 +80,7 @@ class DFG:
             neighbors = self.get_successors(current_node)
 
             if not directed:
-                neighbors.update(self.get_predecessors(current_node))
+                neighbors = neighbors.union(self.get_predecessors(current_node))
 
             for neighbor in neighbors:
                 if neighbor not in visited:

--- a/tests/graphs/dfg_test.py
+++ b/tests/graphs/dfg_test.py
@@ -77,6 +77,12 @@ class TestDFG(unittest.TestCase):
         self.assertIn({"D", "E"}, connected_components)
         self.assertIn({"A", "B", "C"}, connected_components)
 
+    def test_get_reachable_nodes(self):
+        self.assertEqual(self.dfg.get_reachable_nodes("A"), {"A", "B", "C"})
+        self.assertEqual(self.dfg.get_reachable_nodes("B"), {"B", "C"})
+        self.assertEqual(self.dfg.get_reachable_nodes("C"), {"C", "B"})
+        self.assertEqual(self.dfg.get_reachable_nodes("D"), {"D"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/graphs/dfg_test.py
+++ b/tests/graphs/dfg_test.py
@@ -9,44 +9,24 @@ class TestDFG(unittest.TestCase):
         self.dfg = DFG(log)
 
     def test_dfg_init(self):
-        log = [["A", "B", "C"], ["A", "C", "B"]]
-        dfg = DFG(log)
-        self.assertEqual(self.dfg.nodes, {"A", "B", "C"})
+        self.assertEqual(self.dfg.get_nodes(), {"A", "B", "C"})
         self.assertEqual(
-            self.dfg.edges,
-            {("A", "B"): 1, ("B", "C"): 1, ("A", "C"): 1, ("C", "B"): 1},
+            self.dfg.get_edges(),
+            {("A", "B"), ("B", "C"), ("A", "C"), ("C", "B")},
         )
-        self.assertEqual(self.dfg.start_nodes, {"A"})
-        self.assertEqual(self.dfg.end_nodes, {"B", "C"})
+        self.assertEqual(self.dfg.get_start_nodes(), {"A"})
+        self.assertEqual(self.dfg.get_end_nodes(), {"B", "C"})
 
     def test_add_node(self):
         self.dfg.add_node("D")
-        self.assertEqual(self.dfg.nodes, {"A", "B", "C", "D"})
+        self.assertEqual(self.dfg.get_nodes(), {"A", "B", "C", "D"})
 
     def test_add_edge(self):
         self.dfg.add_edge("C", "D")
         self.assertEqual(
-            self.dfg.edges,
-            {("A", "B"): 1, ("B", "C"): 1, ("A", "C"): 1, ("C", "B"): 1, ("C", "D"): 1},
+            self.dfg.get_edges(),
+            {("A", "B"), ("B", "C"), ("A", "C"), ("C", "B"), ("C", "D")},
         )
-
-    def test_adding_existing_edge_increases_weight(self):
-        self.dfg.add_edge("A", "B")
-        self.assertEqual(
-            self.dfg.edges,
-            {("A", "B"): 2, ("B", "C"): 1, ("A", "C"): 1, ("C", "B"): 1},
-        )
-
-    def test_add_edge_with_weight(self):
-        self.dfg.add_edge("C", "D", 3)
-        self.assertEqual(
-            self.dfg.edges,
-            {("A", "B"): 1, ("B", "C"): 1, ("A", "C"): 1, ("C", "B"): 1, ("C", "D"): 3},
-        )
-
-    def test_add_edge_with_negative_weight(self):
-        with self.assertRaises(ValueError):
-            self.dfg.add_edge("C", "D", -3)
 
     def test_get_nodes(self):
         self.assertEqual(self.dfg.get_nodes(), {"A", "B", "C"})
@@ -54,7 +34,7 @@ class TestDFG(unittest.TestCase):
     def test_get_edges(self):
         self.assertEqual(
             self.dfg.get_edges(),
-            {("A", "B"): 1, ("B", "C"): 1, ("A", "C"): 1, ("C", "B"): 1},
+            {("A", "B"), ("B", "C"), ("A", "C"), ("C", "B")},
         )
 
     def test_get_start_nodes(self):
@@ -96,14 +76,6 @@ class TestDFG(unittest.TestCase):
         connected_components = self.dfg.get_connected_components()
         self.assertIn({"D", "E"}, connected_components)
         self.assertIn({"A", "B", "C"}, connected_components)
-
-    def test_is_reachable(self):
-        self.assertTrue(self.dfg.is_reachable("A", "B"))
-        self.assertTrue(self.dfg.is_reachable("A", "C"))
-        self.assertTrue(self.dfg.is_reachable("B", "C"))
-        self.assertFalse(self.dfg.is_reachable("B", "A"))
-        self.assertFalse(self.dfg.is_reachable("C", "A"))
-        self.assertTrue(self.dfg.is_reachable("C", "B"))
 
 
 if __name__ == "__main__":

--- a/tests/graphs/dfg_test.py
+++ b/tests/graphs/dfg_test.py
@@ -83,6 +83,10 @@ class TestDFG(unittest.TestCase):
         self.assertEqual(self.dfg.get_reachable_nodes("C"), {"C", "B"})
         self.assertEqual(self.dfg.get_reachable_nodes("D"), {"D"})
 
+    def test_reachable_nodes_with_node_without_edges(self):
+        self.dfg.add_node("D")
+        self.assertEqual(self.dfg.get_reachable_nodes("D"), {"D"})
+
     def test_node_without_edges_is_stored_in_dfg(self):
         log = [["A", "B"], ["B", "C"], ["C", "A"], ["D", "E"], ["D", "A"], ["F"]]
 

--- a/tests/graphs/dfg_test.py
+++ b/tests/graphs/dfg_test.py
@@ -83,6 +83,66 @@ class TestDFG(unittest.TestCase):
         self.assertEqual(self.dfg.get_reachable_nodes("C"), {"C", "B"})
         self.assertEqual(self.dfg.get_reachable_nodes("D"), {"D"})
 
+    def test_node_without_edges_is_stored_in_dfg(self):
+        log = [["A", "B"], ["B", "C"], ["C", "A"], ["D", "E"], ["D", "A"], ["F"]]
+
+        dfg = DFG(log)
+
+        self.assertEqual(dfg.get_nodes(), {"A", "B", "C", "D", "E", "F"})
+
+    def test_inverting_dfg(self):
+        inverted_dfg = self.dfg.invert()
+
+        self.assertEqual(inverted_dfg.get_nodes(), {"A", "B", "C"})
+        self.assertEqual(
+            inverted_dfg.get_edges(),
+            {("A", "B"), ("B", "A"), ("A", "C"), ("C", "A")},
+        )
+
+    def test_inverting_graph_with_no_edges(self):
+        dfg = DFG([["A"], ["B"], ["C"]])
+
+        inverted_dfg = dfg.invert()
+
+        self.assertEqual(inverted_dfg.get_nodes(), {"A", "B", "C"})
+        self.assertEqual(
+            inverted_dfg.get_edges(),
+            {("A", "B"), ("B", "A"), ("A", "C"), ("C", "A"), ("B", "C"), ("C", "B")},
+        )
+
+    def test_inverting_dfg_with_node_without_edges(self):
+        self.dfg.add_node("D")
+        inverted_dfg = self.dfg.invert()
+
+        self.assertEqual(inverted_dfg.get_nodes(), {"A", "B", "C", "D"})
+        self.assertEqual(
+            inverted_dfg.get_edges(),
+            {
+                ("A", "B"),
+                ("B", "A"),
+                ("A", "C"),
+                ("C", "A"),
+                ("A", "D"),
+                ("D", "A"),
+                ("B", "D"),
+                ("D", "B"),
+                ("C", "D"),
+                ("D", "C"),
+            },
+        )
+
+    def test_create_dfg_without_nodes_whithout_edges(self):
+        dfg_without_nodes = self.dfg.create_dfg_without_nodes({"A", "B"})
+
+        self.assertEqual(dfg_without_nodes.get_nodes(), {"C"})
+        self.assertEqual(dfg_without_nodes.get_edges(), set())
+
+    def test_create_dfg_without_nodes_with_edges(self):
+        dfg_without_nodes = self.dfg.create_dfg_without_nodes({"A"})
+
+        self.assertEqual(dfg_without_nodes.get_nodes(), {"B", "C"})
+        self.assertEqual(dfg_without_nodes.get_edges(), {("B", "C"), ("C", "B")})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Summary:**
This PR adds the enhancement changes mentioned in #28. The inductive miner's performance did significantly decrease, with larger datasets. To improve the performance, checks were added to the exclusive cut and parallel cut, before trying to detect a cut. The sequence cut was the bottleneck in performance. To improve it, the reachability for all nodes is calculated, and the results are stored inside the memory, instead of calculation the reachability for each node pair. Furthermore, the internal structure has been changed, to speed up calculations.

Due to these changes, the performance increased significantly. In the prior implementation, mining a large dataset took on average 6 minutes. By changing the sequence cut the time reduced to 4 seconds on average and with the changes in the DFG the time was cut down to 0.8 second.

**Changes Made:**

DFG

Edges are no longer stored in. a dictionary. Now a successor list and predecessor list is used to store the edges. The predecessor list may be redundant, but has been added to find predecessors fast, for calculating the connected_components of a DFG. Due to this change, neighbors of a node can be found in constant time, instead of linear time. This change speeds up graph traversal.

The method to check if two nodes are reachable from each other has been removed. Instead, a new method has been added to get all reachable nodes from a node. This new function is now used in the sequence cut instead of the previous one.

Additionally, the function to invert a DFG was moved from the cuts.py file inside the DFG class. The function to create a DFG without some nodes has also been moved.

Exclusive Cut and Parallel Cut

The exclusive cut and parallel cut now check the number of end and start nodes, before trying to find a cut. If there only exists one start node or one end node, none of these cuts can be present, and therefore the cut detection can be skipped. This did not increase the performance significantly, as finding connecting components is not a time-consuming task, but has been added anyway.

Sequence Cut

Finding a sequence cut was the most time-consuming operation in the inductive miner. In the previous implementation, it was checked for all node pairs if a path exists from node a to b and node b to a. This has been changed to increase the performance. Now all reachable nodes for each node are calculated and stored in a dictionary. This dictionary is then used to check, for all pair of nodes, if a path exists between two nodes.

**Testing:**
The existing tests have been used to check the correctness after the changes. The following unit test were run:

- graphs.cuts test
- mining_algorithm.inductive_mining_test
- graph.dfg_test

The following tests were added to the dfg_test.py file:
- correctness of inverted dfg, including edge cases
- test correctness of creating a dfg without some nodes, including edge cases
- test get_reachable_nodes
- test that nodes without edges are added to the dfg

**Issues Resolved:**
- #28 