### PR TITLE
Enhancement/set slider values by number input field #38

### DIFF
--- a/components/number_input_slider.py
+++ b/components/number_input_slider.py
@@ -1,0 +1,52 @@
+import streamlit as st
+
+
+def number_input_slider(
+    label: str,
+    min_value: int | float = None,
+    max_value: int | float = None,
+    value: int | float = None,
+    step: int | float = None,
+    key: str = None,
+    help: str = None,
+) -> None:
+    """Renders a slider and a number input field.
+
+    Parameters
+    ----------
+    label : str
+        The label of the slider and number input field.
+    min_value : int | float, optional
+        Minimum value of the slider and number input field, by default None
+    max_value : int | float, optional
+        Maximum value of the slider and number input field, by default None
+    value : int | float, optional
+        Default value of the slider and number input field, by default None
+    step : int | float, optional
+        Step size of the slider, by default None
+    key : str, optional
+        The key of the slider and number input field, by default None
+    help : str, optional
+        Help text of the slider, by default None
+    """
+    st.slider(
+        label=label,
+        min_value=min_value,
+        max_value=max_value,
+        key=key,
+        help=help,
+    )
+
+    st.number_input(
+        label=" ",
+        min_value=min_value,
+        max_value=max_value,
+        value=st.session_state[key] if key in st.session_state else value,
+        key=f"{key}_text_input",
+        on_change=set_session_state,
+        args=(key, f"{key}_text_input"),
+    )
+
+
+def set_session_state(key: str, number_input_key: str) -> None:
+    st.session_state[key] = st.session_state[number_input_key]

--- a/components/number_input_slider.py
+++ b/components/number_input_slider.py
@@ -9,6 +9,7 @@ def number_input_slider(
     step: int | float = None,
     key: str = None,
     help: str = None,
+    ratio: int | list[int] | None = None,
 ) -> None:
     """Renders a slider and a number input field.
 
@@ -28,24 +29,37 @@ def number_input_slider(
         The key of the slider and number input field, by default None
     help : str, optional
         Help text of the slider, by default None
+    ratio : int | list[int] | None, optional
+        The ratio of the slider and number input field, by default None
     """
-    st.slider(
-        label=label,
-        min_value=min_value,
-        max_value=max_value,
-        key=key,
-        help=help,
-    )
 
-    st.number_input(
-        label=" ",
-        min_value=min_value,
-        max_value=max_value,
-        value=st.session_state[key] if key in st.session_state else value,
-        key=f"{key}_text_input",
-        on_change=set_session_state,
-        args=(key, f"{key}_text_input"),
-    )
+    if ratio is None:
+        ratio = [5, 1]
+
+    if isinstance(ratio, list):
+        ratio = ratio[:2]
+
+    silder_column, number_input_column = st.columns(ratio)
+
+    with silder_column:
+        st.slider(
+            label=label,
+            min_value=min_value,
+            max_value=max_value,
+            key=key,
+            help=help,
+        )
+
+    with number_input_column:
+        st.number_input(
+            label=" ",
+            min_value=min_value,
+            max_value=max_value,
+            value=st.session_state[key] if key in st.session_state else value,
+            key=f"{key}_text_input",
+            on_change=set_session_state,
+            args=(key, f"{key}_text_input"),
+        )
 
 
 def set_session_state(key: str, number_input_key: str) -> None:

--- a/ui/fuzzy_miner_ui/fuzzy_miner_view.py
+++ b/ui/fuzzy_miner_ui/fuzzy_miner_view.py
@@ -1,5 +1,6 @@
 from ui.base_algorithm_ui.base_algorithm_view import BaseAlgorithmView
 import streamlit as st
+from components.number_input_slider import number_input_slider
 
 
 class FuzzyMinerView(BaseAlgorithmView):
@@ -17,7 +18,8 @@ class FuzzyMinerView(BaseAlgorithmView):
             The keys of the dictionary are equal to the keys of the sliders.
         """
         st.write("Significance Cutoff")
-        st.slider(
+
+        number_input_slider(
             label="Significance",
             min_value=sidebar_values["significance"][0],
             max_value=sidebar_values["significance"][1],
@@ -25,7 +27,7 @@ class FuzzyMinerView(BaseAlgorithmView):
             help="Significance measures the frequency of events that are observed more frequently and are therefore considered more significant.",
         )
 
-        st.slider(
+        number_input_slider(
             label="Correlation",
             min_value=sidebar_values["correlation"][0],
             max_value=sidebar_values["correlation"][1],
@@ -35,7 +37,7 @@ class FuzzyMinerView(BaseAlgorithmView):
 
         st.write("Edge filtering")
 
-        st.slider(
+        number_input_slider(
             label="Edge Cutoff",
             min_value=sidebar_values["edge_cutoff"][0],
             max_value=sidebar_values["edge_cutoff"][1],
@@ -43,7 +45,7 @@ class FuzzyMinerView(BaseAlgorithmView):
             help="The edge cutoff parameter determines the aggressiviness of the algorithm, i.e. the higher its value, the more likely the algorithm remove edges.",
         )
 
-        st.slider(
+        number_input_slider(
             label="Utility Ratio",
             min_value=sidebar_values["utility_ratio"][0],
             max_value=sidebar_values["utility_ratio"][1],

--- a/ui/heuristic_miner_ui/heuristic_miner_view.py
+++ b/ui/heuristic_miner_ui/heuristic_miner_view.py
@@ -1,5 +1,6 @@
 from ui.base_algorithm_ui.base_algorithm_view import BaseAlgorithmView
 import streamlit as st
+from components.number_input_slider import number_input_slider
 
 
 class HeuristicMinerView(BaseAlgorithmView):
@@ -16,7 +17,8 @@ class HeuristicMinerView(BaseAlgorithmView):
             A dictionary containing the minimum and maximum values for the sidebar sliders.
             The keys of the dictionary are equal to the keys of the sliders.
         """
-        st.slider(
+
+        number_input_slider(
             label="Minimum Frequency",
             min_value=sidebar_values["frequency"][0],
             max_value=sidebar_values["frequency"][1],
@@ -24,33 +26,10 @@ class HeuristicMinerView(BaseAlgorithmView):
             help="Minimum frequency for displaying edges and nodes. Edges with a lower frequency (weight) will be removed. Node with a lower frequency will be removed.",
         )
 
-        st.number_input(
-            label=" ",
-            min_value=sidebar_values["frequency"][0],
-            max_value=sidebar_values["frequency"][1],
-            value=st.session_state.frequency,
-            key="frequency_text_input",
-            on_change=self.set_session_state,
-            args=("frequency", "frequency_text_input"),
-        )
-
-        st.slider(
+        number_input_slider(
             label="Dependency Threshold",
             min_value=sidebar_values["threshold"][0],
             max_value=sidebar_values["threshold"][1],
             key="threshold",
             help="Minimum dependency for displaying edges. Edges with a lower dependency will be removed.",
         )
-
-        st.number_input(
-            label=" ",
-            min_value=sidebar_values["threshold"][0],
-            max_value=sidebar_values["threshold"][1],
-            value=st.session_state.threshold,
-            key="threshold_text_input",
-            on_change=self.set_session_state,
-            args=("threshold", "threshold_text_input"),
-        )
-
-    def set_session_state(self, key, number_input_key) -> None:
-        st.session_state[key] = st.session_state[number_input_key]

--- a/ui/heuristic_miner_ui/heuristic_miner_view.py
+++ b/ui/heuristic_miner_ui/heuristic_miner_view.py
@@ -24,6 +24,16 @@ class HeuristicMinerView(BaseAlgorithmView):
             help="Minimum frequency for displaying edges and nodes. Edges with a lower frequency (weight) will be removed. Node with a lower frequency will be removed.",
         )
 
+        st.number_input(
+            label=" ",
+            min_value=sidebar_values["frequency"][0],
+            max_value=sidebar_values["frequency"][1],
+            value=st.session_state.frequency,
+            key="frequency_text_input",
+            on_change=self.set_session_state,
+            args=("frequency", "frequency_text_input"),
+        )
+
         st.slider(
             label="Dependency Threshold",
             min_value=sidebar_values["threshold"][0],
@@ -31,3 +41,16 @@ class HeuristicMinerView(BaseAlgorithmView):
             key="threshold",
             help="Minimum dependency for displaying edges. Edges with a lower dependency will be removed.",
         )
+
+        st.number_input(
+            label=" ",
+            min_value=sidebar_values["threshold"][0],
+            max_value=sidebar_values["threshold"][1],
+            value=st.session_state.threshold,
+            key="threshold_text_input",
+            on_change=self.set_session_state,
+            args=("threshold", "threshold_text_input"),
+        )
+
+    def set_session_state(self, key, number_input_key) -> None:
+        st.session_state[key] = st.session_state[number_input_key]

--- a/ui/inductive_miner_ui/inductive_miner_view.py
+++ b/ui/inductive_miner_ui/inductive_miner_view.py
@@ -1,5 +1,6 @@
 from ui.base_algorithm_ui.base_algorithm_view import BaseAlgorithmView
 import streamlit as st
+from components.number_input_slider import number_input_slider
 
 
 class InductiveMinerView(BaseAlgorithmView):
@@ -16,7 +17,7 @@ class InductiveMinerView(BaseAlgorithmView):
             A dictionary containing the minimum and maximum values for the sidebar sliders.
             The keys of the dictionary are equal to the keys of the sliders.
         """
-        st.slider(
+        number_input_slider(
             label="Traces Threshold",
             min_value=sidebar_values["traces_threshold"][0],
             max_value=sidebar_values["traces_threshold"][1],
@@ -25,7 +26,7 @@ class InductiveMinerView(BaseAlgorithmView):
             All traces with a frequency that is lower than treshold * max_trace_frequency will be removed. The higher the value, the less traces will be included in the graph.""",
         )
 
-        st.slider(
+        number_input_slider(
             label="Activity Threshold",
             min_value=sidebar_values["activity_threshold"][0],
             max_value=sidebar_values["activity_threshold"][1],


### PR DESCRIPTION
**Summary:**
This PR adds the enhancement changes mentioned in #38. Mining Algorithm parameters can now also be directly set in a number input field. The slider and input field are synchronized

**Changes Made:**

A new component has been created in the components directory. The component consists of a streamlit slider and a streamlit number_input. These two input widgets are synchronized. When one element is changed, the value of the second element is also updated

**Screenshots:**

Old Version:

<img width="537" alt="Bildschirmfoto 2024-06-11 um 21 48 19" src="https://github.com/fabianf00/ProcessMiningVisualization_WS23/assets/93155131/ca012cab-3fbf-47f4-96b3-55a576f9fe99">


New Version:

<img width="519" alt="Bildschirmfoto 2024-06-11 um 21 47 02" src="https://github.com/fabianf00/ProcessMiningVisualization_WS23/assets/93155131/a20056e4-fb9e-4cd0-91f4-2589d4c9781f">